### PR TITLE
Add Simulator support

### DIFF
--- a/MotionOrientation.m
+++ b/MotionOrientation.m
@@ -236,6 +236,8 @@ NSString* const kMotionOrientationKey = @"kMotionOrientationKey";
 {
     [[UIDevice currentDevice] endGeneratingDeviceOrientationNotifications];
     [[NSNotificationCenter defaultCenter] removeObserver:self];
+    
+    [super dealloc];
 }
 
 #endif


### PR DESCRIPTION
Simulator has no accelerometer, so falling back to UIDevice notifications to support Simulator.
For now only device orientation changes (Interface orientation change notifications not implemented).
