### PR TITLE
Fix use of UIInterfaceOrientation constants

### DIFF
--- a/MotionOrientation.h
+++ b/MotionOrientation.h
@@ -24,4 +24,7 @@ extern NSString* const kMotionOrientationKey;
 + (void)initialize;
 + (MotionOrientation *)sharedInstance;
 
+- (void)startAccelerometerUpdates;
+- (void)stopAccelerometerUpdates;
+
 @end

--- a/MotionOrientation.m
+++ b/MotionOrientation.m
@@ -48,9 +48,9 @@ NSString* const kMotionOrientationKey = @"kMotionOrientationKey";
 - (void)_initialize
 {
     self.showDebugLog = NO;
-    
+
     self.operationQueue = [[NSOperationQueue alloc] init];
-    
+
     self.motionManager = [[CMMotionManager alloc] init];
     self.motionManager.accelerometerUpdateInterval = 0.1;
     if ( ![self.motionManager isAccelerometerAvailable] ) {
@@ -76,24 +76,24 @@ NSString* const kMotionOrientationKey = @"kMotionOrientationKey";
 - (CGAffineTransform)affineTransform
 {
     int rotationDegree = 0;
-    
+
     switch (self.interfaceOrientation) {
         case UIInterfaceOrientationPortrait:
             rotationDegree = 0;
             break;
-            
+
         case UIInterfaceOrientationLandscapeLeft:
             rotationDegree = 90;
             break;
-            
+
         case UIInterfaceOrientationPortraitUpsideDown:
             rotationDegree = 180;
             break;
-            
+
         case UIInterfaceOrientationLandscapeRight:
             rotationDegree = 270;
             break;
-            
+
         default:
             break;
     }
@@ -105,6 +105,13 @@ NSString* const kMotionOrientationKey = @"kMotionOrientationKey";
 
 - (void)startAccelerometerUpdates
 {
+    if (![self.motionManager isAccelerometerAvailable]) {
+        if ( self.showDebugLog ) {
+            NSLog(@"MotionOrientation - Accelerometer is NOT available");
+        }
+        return;
+    }
+
     [self.motionManager startAccelerometerUpdatesToQueue:self.operationQueue withHandler:^(CMAccelerometerData *accelerometerData, NSError *error) {
         [self accelerometerUpdateWithData:accelerometerData error:error];
     }];
@@ -123,24 +130,24 @@ NSString* const kMotionOrientationKey = @"kMotionOrientationKey";
         }
         return;
     }
-    
+
     CMAcceleration acceleration = accelerometerData.acceleration;
-    
+
     // Get the current device angle
 	float xx = -acceleration.x;
 	float yy = acceleration.y;
     float z = acceleration.z;
-	float angle = atan2(yy, xx); 
+	float angle = atan2(yy, xx);
     float absoluteZ = (float)fabs(acceleration.z);
-    
+
 	// Add 1.5 to the angle to keep the label constantly horizontal to the viewer.
-    //	[interfaceOrientationLabel setTransform:CGAffineTransformMakeRotation(angle+1.5)]; 
-    
+    //	[interfaceOrientationLabel setTransform:CGAffineTransformMakeRotation(angle+1.5)];
+
 	// Read my blog for more details on the angles. It should be obvious that you
 	// could fire a custom shouldAutorotateToInterfaceOrientation-event here.
     UIInterfaceOrientation newInterfaceOrientation = self.interfaceOrientation;
     UIDeviceOrientation newDeviceOrientation = self.deviceOrientation;
-    
+
 #ifdef DEBUG
     NSString* orientationString = nil;
 #endif
@@ -194,17 +201,17 @@ NSString* const kMotionOrientationKey = @"kMotionOrientationKey";
         orientationString = @"MotionOrientation - Right";
 #endif
 	} else {
-        
+
     }
 
     BOOL deviceOrientationChanged = NO;
     BOOL interfaceOrientationChanged = NO;
-    
+
     if ( newDeviceOrientation != self.deviceOrientation ) {
         deviceOrientationChanged = YES;
         _deviceOrientation = newDeviceOrientation;
     }
-    
+
     if ( newInterfaceOrientation != self.interfaceOrientation ) {
         interfaceOrientationChanged = YES;
         _interfaceOrientation = newInterfaceOrientation;
@@ -212,19 +219,19 @@ NSString* const kMotionOrientationKey = @"kMotionOrientationKey";
 
     // post notifications
     if ( deviceOrientationChanged ) {
-        [[NSNotificationCenter defaultCenter] postNotificationName:MotionOrientationChangedNotification 
-                                                            object:nil 
+        [[NSNotificationCenter defaultCenter] postNotificationName:MotionOrientationChangedNotification
+                                                            object:nil
                                                           userInfo:[NSDictionary dictionaryWithObjectsAndKeys:self, kMotionOrientationKey, nil]];
         if ( self.showDebugLog ) {
             NSLog(@"didAccelerate: absoluteZ: %f angle: %f (x: %f, y: %f, z: %f), orientationString: %@",
-                  absoluteZ, angle, 
-                  acceleration.x, acceleration.y, acceleration.z, 
+                  absoluteZ, angle,
+                  acceleration.x, acceleration.y, acceleration.z,
                   orientationString);
         }
     }
     if ( interfaceOrientationChanged ) {
-        [[NSNotificationCenter defaultCenter] postNotificationName:MotionOrientationInterfaceOrientationChangedNotification 
-                                                            object:nil 
+        [[NSNotificationCenter defaultCenter] postNotificationName:MotionOrientationInterfaceOrientationChangedNotification
+                                                            object:nil
                                                           userInfo:[NSDictionary dictionaryWithObjectsAndKeys:self, kMotionOrientationKey, nil]];
     }
 }
@@ -255,7 +262,7 @@ NSString* const kMotionOrientationKey = @"kMotionOrientationKey";
 {
     [[UIDevice currentDevice] endGeneratingDeviceOrientationNotifications];
     [[NSNotificationCenter defaultCenter] removeObserver:self];
-    
+
 #if __has_feature(objc_arc)
 #else
     [super dealloc];

--- a/MotionOrientation.m
+++ b/MotionOrientation.m
@@ -62,9 +62,6 @@ NSString* const kMotionOrientationKey = @"kMotionOrientationKey";
 #endif
         return;
     }
-    [self.motionManager startAccelerometerUpdatesToQueue:self.operationQueue withHandler:^(CMAccelerometerData *accelerometerData, NSError *error) {
-        [self accelerometerUpdateWithData:accelerometerData error:error];
-    }];
 }
 
 - (id)init
@@ -104,6 +101,18 @@ NSString* const kMotionOrientationKey = @"kMotionOrientationKey";
         NSLog(@"affineTransform degree: %d", rotationDegree);
     }
     return CGAffineTransformMakeRotation(MO_degreesToRadian(rotationDegree));
+}
+
+- (void)startAccelerometerUpdates
+{
+    [self.motionManager startAccelerometerUpdatesToQueue:self.operationQueue withHandler:^(CMAccelerometerData *accelerometerData, NSError *error) {
+        [self accelerometerUpdateWithData:accelerometerData error:error];
+    }];
+}
+
+- (void)stopAccelerometerUpdates
+{
+    [self.motionManager stopAccelerometerUpdates];
 }
 
 - (void)accelerometerUpdateWithData:(CMAccelerometerData *)accelerometerData error:(NSError *)error

--- a/MotionOrientation.m
+++ b/MotionOrientation.m
@@ -82,7 +82,7 @@ NSString* const kMotionOrientationKey = @"kMotionOrientationKey";
             rotationDegree = 0;
             break;
 
-        case UIInterfaceOrientationLandscapeLeft:
+        case UIInterfaceOrientationLandscapeRight:
             rotationDegree = 90;
             break;
 
@@ -90,7 +90,7 @@ NSString* const kMotionOrientationKey = @"kMotionOrientationKey";
             rotationDegree = 180;
             break;
 
-        case UIInterfaceOrientationLandscapeRight:
+        case UIInterfaceOrientationLandscapeLeft:
             rotationDegree = 270;
             break;
 
@@ -176,7 +176,7 @@ NSString* const kMotionOrientationKey = @"kMotionOrientationKey";
 	}
 	else if(angle >= -0.5 && angle <= 0.5) // (angle >= -0.75 && angle <= 0.75)
 	{
-        newInterfaceOrientation = UIInterfaceOrientationLandscapeLeft;
+        newInterfaceOrientation = UIInterfaceOrientationLandscapeRight;
         newDeviceOrientation = UIDeviceOrientationLandscapeLeft;
         //self.captureVideoOrientation = AVCaptureVideoOrientationLandscapeRight;
 #ifdef DEBUG
@@ -194,7 +194,7 @@ NSString* const kMotionOrientationKey = @"kMotionOrientationKey";
 	}
 	else if(angle <= -2.5 || angle >= 2.5) // (angle <= -2.25 || angle >= 2.25)
 	{
-        newInterfaceOrientation = UIInterfaceOrientationLandscapeRight;
+        newInterfaceOrientation = UIInterfaceOrientationLandscapeLeft;
         newDeviceOrientation = UIDeviceOrientationLandscapeRight;
         //self.captureVideoOrientation = AVCaptureVideoOrientationLandscapeLeft;
 #ifdef DEBUG


### PR DESCRIPTION
According to the documentation, UIDeviceOrientationLandscapeLeft and UIInterfaceOrientationLandscapeLeft are not the same. In fact, they are the exact opposite.

Take a look at the definition of UIInterfaceOrientation:

```
// Note that UIInterfaceOrientationLandscapeLeft is equal to UIDeviceOrientationLandscapeRight (and vice versa).
// This is because rotating the device to the left requires rotating the content to the right.
typedef NS_ENUM(NSInteger, UIInterfaceOrientation) {
    UIInterfaceOrientationUnknown            = UIDeviceOrientationUnknown,
    UIInterfaceOrientationPortrait           = UIDeviceOrientationPortrait,
    UIInterfaceOrientationPortraitUpsideDown = UIDeviceOrientationPortraitUpsideDown,
    UIInterfaceOrientationLandscapeLeft      = UIDeviceOrientationLandscapeRight,
    UIInterfaceOrientationLandscapeRight     = UIDeviceOrientationLandscapeLeft
};
```

That being said, I noticed that when <code>newInterfaceOrientation</code> was being calculated in <code>MotionOrientation.m:179 and MotionOrientation.m:197</code>, the constant was not being flipped.

This fix also affected <code>\- (CGAffineTransform)affineTransform</code>, which was also fixed.
